### PR TITLE
upgrade-snowflake-connector-python-to-3.15

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.10
 WORKDIR /home
 
 COPY test-requirements.txt .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chm_utils"
-version = "0.2.2"
+version = "0.2.4"
 dependencies = [
   "boto3",
   "PyYAML"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dependencies = [
   "boto3",
   "PyYAML"
 ]
-requires-python = ">=3.8"
+requires-python = ">3.8"
 authors = [
   {name = "Adrian Oesch", email = "helloadrianoesch@chmedia.ch"},
 ]
@@ -14,7 +14,7 @@ readme = "readme.md"
 
 [project.optional-dependencies]
 snowflake = [
-  "snowflake-connector-python[pandas]>=3.12.0",
+  "snowflake-connector-python[pandas]>=3.15.0",
 ]
 redis = [
   "redis"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,4 +2,4 @@ pytest
 boto3
 PyYAML
 dash>=2.7.0
-snowflake-connector-python[pandas]>=3.12.0
+snowflake-connector-python[pandas]>=3.15.0


### PR DESCRIPTION
- According https://status.snowflake.com/incidents/txclg2cyzq32 we need to upgrade the package to avoid running into SSL errors
- With newer versions, support for python 3.8 has been dropped